### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/323/19/85632319.geojson
+++ b/data/856/323/19/85632319.geojson
@@ -1000,6 +1000,11 @@
     },
     "wof:country":"DJ",
     "wof:country_alpha3":"DJI",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"27caa411176bc6b1326586e503015be9",
     "wof:hierarchy":[
         {
@@ -1016,7 +1021,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566721452,
+    "wof:lastmodified":1582332266,
     "wof:name":"Djibouti",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/704/67/85670467.geojson
+++ b/data/856/704/67/85670467.geojson
@@ -343,6 +343,9 @@
         "wd:id":"Q821008"
     },
     "wof:country":"DJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"787f6a3052260c2266c628745e8b6ec0",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566721452,
+    "wof:lastmodified":1582332267,
     "wof:name":"Ali Sabieh",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/73/85670473.geojson
+++ b/data/856/704/73/85670473.geojson
@@ -494,6 +494,9 @@
         "wd:id":"Q3604"
     },
     "wof:country":"DJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"357b7e3fb4f0d2b74540971aa56212ab",
     "wof:hierarchy":[
         {
@@ -511,7 +514,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566721452,
+    "wof:lastmodified":1582332267,
     "wof:name":"Djibouti",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/77/85670477.geojson
+++ b/data/856/704/77/85670477.geojson
@@ -322,6 +322,9 @@
         "wd:id":"Q705941"
     },
     "wof:country":"DJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6a400827ce117c04e4f0ded93f86a5e9",
     "wof:hierarchy":[
         {
@@ -339,7 +342,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566721453,
+    "wof:lastmodified":1582332267,
     "wof:name":"Arta",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/83/85670483.geojson
+++ b/data/856/704/83/85670483.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Dikhil Region"
     },
     "wof:country":"DJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17ee99471212c6384533a69974b69d57",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566721453,
+    "wof:lastmodified":1582332267,
     "wof:name":"Dikhil",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/85/85670485.geojson
+++ b/data/856/704/85/85670485.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Obock Region"
     },
     "wof:country":"DJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"96962da1b1dc1e4a8b1b0f62d5ca4367",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566721453,
+    "wof:lastmodified":1582332267,
     "wof:name":"Obock",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/91/85670491.geojson
+++ b/data/856/704/91/85670491.geojson
@@ -289,6 +289,9 @@
         "wd:id":"Q645896"
     },
     "wof:country":"DJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9bb40af91fbd41f12d21a52d40be140",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566721453,
+    "wof:lastmodified":1582332267,
     "wof:name":"Tadjourah",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/859/028/83/85902883.geojson
+++ b/data/859/028/83/85902883.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Boul'aos"
     },
     "wof:country":"DJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bc1d081cf3ee7cbb096a02e5fa5b8dc6",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1534379286,
+    "wof:lastmodified":1582332266,
     "wof:name":"Bo\u00fbl\u2019aws",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/028/87/85902887.geojson
+++ b/data/859/028/87/85902887.geojson
@@ -98,6 +98,9 @@
         "qs_pg:id":238641
     },
     "wof:country":"DJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f47860a79ae8c33a5d00e232feb97fc9",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566721452,
+    "wof:lastmodified":1582332266,
     "wof:name":"La Plaine",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.