### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/577/980/9/1125779809.geojson
+++ b/data/112/577/980/9/1125779809.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0647\u0644\u0647\u0648\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0647\u0644\u0647\u0648\u0644"
+    ],
     "name:azb_x_preferred":[
         "\u0647\u0644\u0647\u0648\u0644"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:fra_x_preferred":[
         "Holhol"
+    ],
+    "name:hye_x_preferred":[
+        "\u0540\u0578\u056c\u0570\u0578\u056c"
     ],
     "name:ita_x_preferred":[
         "Holhol"
@@ -69,6 +75,9 @@
     ],
     "name:urd_x_preferred":[
         "\u062d\u0644\u062d\u0648\u0644"
+    ],
+    "name:zho_x_preferred":[
+        "\u970d\u52d2\u970d\u52d2"
     ],
     "qs_pg:aaroncc":"DJ",
     "qs_pg:gn_country":"DJ",
@@ -109,7 +118,7 @@
         }
     ],
     "wof:id":1125779809,
-    "wof:lastmodified":1566721458,
+    "wof:lastmodified":1690874643,
     "wof:name":"Holhol",
     "wof:parent_id":1108759739,
     "wof:placetype":"locality",

--- a/data/112/581/899/5/1125818995.geojson
+++ b/data/112/581/899/5/1125818995.geojson
@@ -25,11 +25,17 @@
     "name:ara_x_preferred":[
         "\u0623\u0631\u062a\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Arta"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0631\u062a\u0627"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0440\u0442\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u0410\u0440\u0442\u0430"
     ],
     "name:ceb_x_preferred":[
         "\u2018Arta"
@@ -46,11 +52,15 @@
     "name:est_x_preferred":[
         "Arta"
     ],
+    "name:eus_x_preferred":[
+        "Arta"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0631\u062a\u0627\u060c \u062c\u06cc\u0628\u0648\u062a\u06cc"
     ],
     "name:fas_x_variant":[
-        "\u0627\u0631\u062a\u0627"
+        "\u0627\u0631\u062a\u0627",
+        "\u0639\u0631\u062a\u0627"
     ],
     "name:fin_x_preferred":[
         "Arta"
@@ -60,6 +70,9 @@
     ],
     "name:frr_x_preferred":[
         "Arta"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e2\u05e8\u05ea\u05d4"
     ],
     "name:ita_x_preferred":[
         "Arta"
@@ -103,6 +116,9 @@
     "name:tur_x_preferred":[
         "Arta"
     ],
+    "name:ukr_x_preferred":[
+        "\u0410\u0440\u0442\u0430"
+    ],
     "name:urd_x_preferred":[
         "\u0622\u0631\u062a\u0627\u060c \u062c\u0628\u0648\u062a\u06cc"
     ],
@@ -114,6 +130,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u723e\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Arta"
     ],
     "qs_pg:aaroncc":"DJ",
     "qs_pg:gn_country":"DJ",
@@ -154,7 +173,7 @@
         }
     ],
     "wof:id":1125818995,
-    "wof:lastmodified":1566721458,
+    "wof:lastmodified":1690874643,
     "wof:name":"\u2018Arta",
     "wof:parent_id":1108759745,
     "wof:placetype":"locality",

--- a/data/421/166/443/421166443.geojson
+++ b/data/421/166/443/421166443.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062a\u0627\u062c\u0648\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0627\u062c\u0648\u0631\u0647"
+    ],
     "name:ast_x_preferred":[
         "Tadjoura"
     ],
@@ -28,6 +31,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0422\u0430\u0434\u0436\u0443\u0440\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u0422\u0430\u0434\u0436\u0443\u0440\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a4\u09be\u09a6\u099c\u09cc\u09b0\u09be"
@@ -53,6 +59,9 @@
     "name:est_x_preferred":[
         "Tadjoura"
     ],
+    "name:eus_x_preferred":[
+        "Tadjoura"
+    ],
     "name:fas_x_preferred":[
         "\u062a\u0627\u062c\u0648\u0631\u0647"
     ],
@@ -64,6 +73,9 @@
     ],
     "name:frr_x_preferred":[
         "Tadjourah"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d8\u05d0\u05d2'\u05d5\u05e8\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u0924\u093e\u091c\u094b\u090a\u0930\u093e"
@@ -107,6 +119,9 @@
     "name:por_x_preferred":[
         "Tadjourah"
     ],
+    "name:pus_x_preferred":[
+        "\u062a\u0627\u062c\u0648\u0631\u0647"
+    ],
     "name:ron_x_preferred":[
         "Tadjourah"
     ],
@@ -133,6 +148,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5854\u6731\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Tadjoura"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Djibouti",
@@ -277,7 +295,7 @@
         }
     ],
     "wof:id":421166443,
-    "wof:lastmodified":1636497600,
+    "wof:lastmodified":1690874641,
     "wof:name":"Tadjoura",
     "wof:parent_id":1108759769,
     "wof:placetype":"locality",

--- a/data/421/168/675/421168675.geojson
+++ b/data/421/168/675/421168675.geojson
@@ -20,11 +20,20 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0628\u0648\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0628\u0648\u0643"
+    ],
     "name:ast_x_preferred":[
         "Obock"
     ],
+    "name:azb_x_preferred":[
+        "\u0627\u0648\u0628\u0648\u06a9"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0431\u043e\u043a"
+    ],
+    "name:bel_x_variant":[
+        "\u0410\u0431\u043e\u043a"
     ],
     "name:ben_x_preferred":[
         "\u0993\u09ac\u09cb\u0995"
@@ -51,6 +60,9 @@
         "Obock"
     ],
     "name:est_x_preferred":[
+        "Obock"
+    ],
+    "name:eus_x_preferred":[
         "Obock"
     ],
     "name:fas_x_preferred":[
@@ -95,6 +107,9 @@
     "name:nld_x_preferred":[
         "Obock"
     ],
+    "name:nob_x_preferred":[
+        "Obock"
+    ],
     "name:pol_x_preferred":[
         "Obock"
     ],
@@ -130,6 +145,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5967\u535a\u514b"
+    ],
+    "name:zul_x_preferred":[
+        "Obock"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Djibouti",
@@ -274,7 +292,7 @@
         }
     ],
     "wof:id":421168675,
-    "wof:lastmodified":1636497600,
+    "wof:lastmodified":1690874641,
     "wof:name":"Obock",
     "wof:parent_id":1108759759,
     "wof:placetype":"locality",

--- a/data/421/170/751/421170751.geojson
+++ b/data/421/170/751/421170751.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0644\u0648\u064a\u0627\u062f\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0648\u064a\u0627\u062f\u0627"
+    ],
     "name:azb_x_preferred":[
         "\u0644\u0648\u06cc\u0627\u062f\u0627"
     ],
@@ -44,10 +47,19 @@
     "name:ita_x_preferred":[
         "Loyada"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ed\u30ef\u30a4\u30e4\u30c0"
+    ],
     "name:nld_x_preferred":[
         "Loyada"
     ],
     "name:pol_x_preferred":[
+        "Loyada"
+    ],
+    "name:pus_x_preferred":[
+        "\u0644\u0648\u064a\u0627\u062f\u0627"
+    ],
+    "name:srn_x_preferred":[
         "Loyada"
     ],
     "name:swe_x_preferred":[
@@ -107,7 +119,7 @@
         }
     ],
     "wof:id":421170751,
-    "wof:lastmodified":1566721457,
+    "wof:lastmodified":1690874642,
     "wof:name":"Loyada",
     "wof:parent_id":1108759745,
     "wof:placetype":"locality",

--- a/data/421/179/947/421179947.geojson
+++ b/data/421/179/947/421179947.geojson
@@ -20,8 +20,17 @@
     "name:ara_x_preferred":[
         "\u062f\u062e\u064a\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u062e\u064a\u0644"
+    ],
+    "name:ast_x_preferred":[
+        "Dikhil"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0414\u044b\u0445\u0456\u043b"
+    ],
+    "name:bel_x_variant":[
+        "\u0414\u044b\u0445\u0456\u043b"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u09bf\u0996\u09bf\u09b2"
@@ -42,6 +51,9 @@
         "Dikhil"
     ],
     "name:est_x_preferred":[
+        "Dikhil"
+    ],
+    "name:eus_x_preferred":[
         "Dikhil"
     ],
     "name:fas_x_preferred":[
@@ -127,6 +139,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8fea\u57fa\u52d2"
+    ],
+    "name:zul_x_preferred":[
+        "Dikhil"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Djibouti",
@@ -271,7 +286,7 @@
         }
     ],
     "wof:id":421179947,
-    "wof:lastmodified":1636497600,
+    "wof:lastmodified":1690874642,
     "wof:name":"Dikhil",
     "wof:parent_id":1108759751,
     "wof:placetype":"locality",

--- a/data/421/196/717/421196717.geojson
+++ b/data/421/196/717/421196717.geojson
@@ -20,11 +20,17 @@
     "name:ara_x_preferred":[
         "\u0639\u0644\u0627\u064a\u0644\u064a \u062f\u0627\u062f\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u0644\u0627\u064a\u0644\u0649 \u062f\u0627\u062f\u0627"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0644\u0627\u06cc\u0644\u06cc \u062f\u0627\u062f\u0627"
     ],
     "name:ceb_x_preferred":[
         "Ala\u00efli \u1e0ea\u1e0f\u1e0fa\u2018"
+    ],
+    "name:deu_x_preferred":[
+        "Alaili Dadda"
     ],
     "name:eng_x_preferred":[
         "Alaili Dadda`"
@@ -106,7 +112,7 @@
         }
     ],
     "wof:id":421196717,
-    "wof:lastmodified":1566721457,
+    "wof:lastmodified":1690874642,
     "wof:name":"Ala\u00efli \u1e0ea\u1e0f\u1e0fa\u2019",
     "wof:parent_id":1108759757,
     "wof:placetype":"locality",

--- a/data/421/196/721/421196721.geojson
+++ b/data/421/196/721/421196721.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062f\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0631\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u0631\u0647"
     ],
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421196721,
-    "wof:lastmodified":1566721457,
+    "wof:lastmodified":1690874642,
     "wof:name":"Dorra",
     "wof:parent_id":1108759765,
     "wof:placetype":"locality",

--- a/data/421/196/723/421196723.geojson
+++ b/data/421/196/723/421196723.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u063a\u0627\u0644\u0627\u0641\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0627\u0644\u0627\u0641\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u063a\u0627\u0644\u0627\u0641\u06cc"
     ],
@@ -41,6 +44,9 @@
     "name:ita_x_preferred":[
         "Galafi"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ac\u30e9\u30d5\u30a3"
+    ],
     "name:nld_x_preferred":[
         "Galafi"
     ],
@@ -55,6 +61,9 @@
     ],
     "name:tur_x_preferred":[
         "Galafi"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0413\u0430\u043b\u0430\u0444\u0456"
     ],
     "name:urd_x_preferred":[
         "\u063a\u0627\u0644\u0627\u0641\u06cc"
@@ -107,7 +116,7 @@
         }
     ],
     "wof:id":421196723,
-    "wof:lastmodified":1566721457,
+    "wof:lastmodified":1690874641,
     "wof:name":"Galafi",
     "wof:parent_id":1108759753,
     "wof:placetype":"locality",

--- a/data/421/204/195/421204195.geojson
+++ b/data/421/204/195/421204195.geojson
@@ -26,11 +26,23 @@
     "name:ara_x_preferred":[
         "\u062c\u064a\u0628\u0648\u062a\u064a"
     ],
+    "name:arg_x_preferred":[
+        "Chibuti"
+    ],
+    "name:ary_x_preferred":[
+        "\u062f\u062c\u064a\u0628\u0648\u062a\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u062c\u064a\u0628\u0648\u062a\u0649"
+    ],
     "name:ast_x_preferred":[
         "Xibuti"
     ],
     "name:aze_x_preferred":[
         "Cibuti"
+    ],
+    "name:ban_x_preferred":[
+        "Djibouti"
     ],
     "name:bcl_x_preferred":[
         "Djibouti"
@@ -91,6 +103,9 @@
     ],
     "name:deu_x_preferred":[
         "Dschibuti"
+    ],
+    "name:diq_x_preferred":[
+        "Cibuti"
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b6\u03b9\u03bc\u03c0\u03bf\u03c5\u03c4\u03af"
@@ -173,8 +188,14 @@
     "name:ido_x_preferred":[
         "Djibouti"
     ],
+    "name:ina_x_preferred":[
+        "Djibuti"
+    ],
     "name:ind_x_preferred":[
         "Djibouti"
+    ],
+    "name:ind_x_variant":[
+        "Jibouti"
     ],
     "name:isl_x_preferred":[
         "Dj\u00edb\u00fat\u00ed"
@@ -215,6 +236,9 @@
     "name:lav_x_preferred":[
         "D\u017eibuti"
     ],
+    "name:lij_x_preferred":[
+        "Gibuti"
+    ],
     "name:lit_x_preferred":[
         "D\u017eibutis"
     ],
@@ -227,6 +251,9 @@
     "name:mar_x_preferred":[
         "\u091c\u093f\u092c\u0942\u0924\u0940"
     ],
+    "name:mdf_x_preferred":[
+        "\u0414\u0436\u0438\u0431\u0443\u0442\u0438"
+    ],
     "name:mkd_x_preferred":[
         "\u040f\u0438\u0431\u0443\u0442\u0438"
     ],
@@ -238,6 +265,12 @@
     ],
     "name:msa_x_preferred":[
         "Djibouti"
+    ],
+    "name:mzn_x_preferred":[
+        "\u062c\u06cc\u0628\u0648\u062a\u06cc"
+    ],
+    "name:nah_x_preferred":[
+        "Altepetl Yibuti"
     ],
     "name:nan_x_preferred":[
         "Djibouti Chh\u012b"
@@ -260,6 +293,12 @@
     "name:oci_x_preferred":[
         "Jiboti"
     ],
+    "name:olo_x_preferred":[
+        "D\u017eibuti"
+    ],
+    "name:oss_x_preferred":[
+        "\u0414\u0436\u0438\u0431\u0443\u0442\u0438"
+    ],
     "name:pan_x_preferred":[
         "\u0a1c\u0a3f\u0a2c\u0a42\u0a24\u0a40"
     ],
@@ -274,6 +313,9 @@
     ],
     "name:por_x_preferred":[
         "Djibouti"
+    ],
+    "name:que_x_preferred":[
+        "Yiwuti"
     ],
     "name:ron_x_preferred":[
         "Djibouti"
@@ -293,6 +335,15 @@
     "name:slv_x_preferred":[
         "D\u017eibuti"
     ],
+    "name:sme_x_preferred":[
+        "Djibouti"
+    ],
+    "name:smn_x_preferred":[
+        "Djibouti"
+    ],
+    "name:sms_x_preferred":[
+        "Djibouti"
+    ],
     "name:sna_x_preferred":[
         "Djibouti"
     ],
@@ -304,6 +355,9 @@
     ],
     "name:sqi_x_preferred":[
         "Xhibuti"
+    ],
+    "name:srd_x_preferred":[
+        "Gibuti"
     ],
     "name:srp_x_preferred":[
         "\u040f\u0438\u0431\u0443\u0442\u0438"
@@ -320,6 +374,9 @@
     "name:tam_x_variant":[
         "\u0b9a\u0bbf\u0baa\u0bc2\u0b9f\u0bcd\u0b9f\u0bbf"
     ],
+    "name:tat_x_preferred":[
+        "\u0496\u0438\u0431\u0443\u0442\u0438"
+    ],
     "name:tel_x_preferred":[
         "\u0c1c\u0c3f\u0c2c\u0c4b\u0c1f\u0c3f"
     ],
@@ -335,6 +392,9 @@
     "name:tuk_x_preferred":[
         "Jibuti"
     ],
+    "name:tum_x_preferred":[
+        "Djibouti"
+    ],
     "name:tur_x_preferred":[
         "Cibuti"
     ],
@@ -346,6 +406,9 @@
     ],
     "name:urd_x_preferred":[
         "\u062c\u0628\u0648\u062a\u06cc \u0639\u0644\u0627\u0642\u06c1"
+    ],
+    "name:urd_x_variant":[
+        "\u062c\u0628\u0648\u062a\u06cc"
     ],
     "name:uzb_x_preferred":[
         "Jibuti"
@@ -365,6 +428,9 @@
     "name:wol_x_preferred":[
         "Jibuti"
     ],
+    "name:wuu_x_preferred":[
+        "\u5409\u5e03\u63d0\u5e02"
+    ],
     "name:xmf_x_preferred":[
         "\u10ef\u10d8\u10d1\u10e3\u10e2\u10d8"
     ],
@@ -382,6 +448,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5409\u5e03\u5730\u5e02"
+    ],
+    "name:zul_x_preferred":[
+        "Djibouti"
     ],
     "ne:ADM0CAP":1.0,
     "ne:ADM0NAME":"Djibouti",
@@ -498,8 +567,8 @@
     "wof:belongsto":[
         102191573,
         85632319,
-        1108759755,
-        85670473
+        85670473,
+        1108759755
     ],
     "wof:breaches":[],
     "wof:capital_of":[
@@ -526,7 +595,7 @@
         }
     ],
     "wof:id":421204195,
-    "wof:lastmodified":1607390888,
+    "wof:lastmodified":1690874641,
     "wof:name":"Djibouti",
     "wof:parent_id":85670473,
     "wof:placetype":"locality",

--- a/data/856/323/19/85632319.geojson
+++ b/data/856/323/19/85632319.geojson
@@ -31,6 +31,9 @@
     "name:aar_x_preferred":[
         "Yabuuti"
     ],
+    "name:abk_x_preferred":[
+        "\u040f\u044c\u0438\u0431\u0443\u0442\u0438"
+    ],
     "name:ace_x_preferred":[
         "Djibouti"
     ],
@@ -55,6 +58,12 @@
     "name:amh_x_variant":[
         "\u1302\u1261\u1272"
     ],
+    "name:ang_x_preferred":[
+        "Cibuti"
+    ],
+    "name:anp_x_preferred":[
+        "\u091c\u093f\u092c\u0942\u091f\u0940"
+    ],
     "name:ara_x_preferred":[
         "\u062c\u064a\u0628\u0648\u062a\u064a"
     ],
@@ -72,6 +81,9 @@
     ],
     "name:ast_x_variant":[
         "Xibuti"
+    ],
+    "name:avk_x_preferred":[
+        "Jibutia"
     ],
     "name:azb_x_preferred":[
         "\u062c\u06cc\u0628\u0648\u062a\u06cc"
@@ -91,6 +103,9 @@
     "name:ban_x_preferred":[
         "Djibouti"
     ],
+    "name:bar_x_preferred":[
+        "Dschibuti"
+    ],
     "name:bcl_x_preferred":[
         "Dibouti"
     ],
@@ -102,6 +117,9 @@
     ],
     "name:bho_x_preferred":[
         "\u091c\u093f\u092c\u0942\u0924\u0940"
+    ],
+    "name:bis_x_preferred":[
+        "Jibuti"
     ],
     "name:bjn_x_preferred":[
         "Djibouti"
@@ -148,6 +166,9 @@
     "name:che_x_preferred":[
         "\u0414\u0436\u0438\u0431\u0443\u0442\u0438"
     ],
+    "name:chr_x_preferred":[
+        "\u13e5\u13ca\u13d7"
+    ],
     "name:chv_x_preferred":[
         "\u0414\u0436\u0438\u0431\u0443\u0442\u0438"
     ],
@@ -156,6 +177,9 @@
     ],
     "name:cor_x_preferred":[
         "Jibouti"
+    ],
+    "name:cos_x_preferred":[
+        "D\u00edbuti"
     ],
     "name:crh_x_preferred":[
         "Cibuti"
@@ -169,6 +193,9 @@
     "name:cze_x_variant":[
         "D\u017eibuti",
         "D\u017eib\u00fati"
+    ],
+    "name:dag_x_preferred":[
+        "Djibouti"
     ],
     "name:dan_x_preferred":[
         "Djibouti"
@@ -193,6 +220,9 @@
     ],
     "name:div_x_preferred":[
         "\u0796\u07a8\u0784\u07aa\u078c\u07a9"
+    ],
+    "name:dsb_x_preferred":[
+        "D\u017eibuti"
     ],
     "name:dty_x_preferred":[
         "\u091c\u093f\u092c\u0941\u091f\u0940"
@@ -269,6 +299,9 @@
     "name:ful_x_preferred":[
         "Jibutii"
     ],
+    "name:ful_x_variant":[
+        "Jibuuti"
+    ],
     "name:gag_x_preferred":[
         "Cibuti"
     ],
@@ -296,6 +329,9 @@
     "name:gom_x_preferred":[
         "\u091c\u093f\u092c\u0942\u0924\u0940"
     ],
+    "name:gpe_x_preferred":[
+        "Djibouti"
+    ],
     "name:grn_x_preferred":[
         "Jimb\u00fati"
     ],
@@ -307,6 +343,9 @@
     ],
     "name:guj_x_variant":[
         "\u0a9c\u0abf\u0aac\u0acb\u0a9f\u0ac0"
+    ],
+    "name:gur_x_preferred":[
+        "Djibouti"
     ],
     "name:hak_x_preferred":[
         "Djibouti"
@@ -366,6 +405,9 @@
     "name:ina_x_preferred":[
         "Djibouti"
     ],
+    "name:ina_x_variant":[
+        "Djibuti"
+    ],
     "name:ind_x_preferred":[
         "Djibouti"
     ],
@@ -393,6 +435,9 @@
     "name:jpn_x_variant":[
         "\u30b8\u30d6\u30c1\u5171\u548c\u56fd"
     ],
+    "name:kaa_x_preferred":[
+        "Djibuti"
+    ],
     "name:kab_x_preferred":[
         "Jibuti"
     ],
@@ -414,8 +459,14 @@
     "name:kbp_x_preferred":[
         "Cibuuti"
     ],
+    "name:kcg_x_preferred":[
+        "Ji\u0331buti"
+    ],
     "name:khm_x_preferred":[
         "\u17a0\u17d2\u179f\u17c9\u17b8\u1794\u17bc\u1791\u17b8"
+    ],
+    "name:khm_x_variant":[
+        "\u1787\u17b8\u1794\u17bc\u1791\u17b8"
     ],
     "name:kik_x_preferred":[
         "Djibouti"
@@ -477,6 +528,9 @@
     "name:lit_x_preferred":[
         "D\u017eibutis"
     ],
+    "name:lld_x_preferred":[
+        "Gibuti"
+    ],
     "name:lmo_x_preferred":[
         "Djibouti"
     ],
@@ -501,6 +555,9 @@
     "name:lzh_x_preferred":[
         "\u5409\u5e03\u5730"
     ],
+    "name:mad_x_preferred":[
+        "Djibouti"
+    ],
     "name:mai_x_preferred":[
         "\u091c\u093f\u092c\u0942\u0924\u0940"
     ],
@@ -512,6 +569,12 @@
     ],
     "name:mar_x_variant":[
         "\u091c\u093f\u092c\u094c\u091f\u0940"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0414\u0436\u0438\u0431\u0443\u0442\u0438"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0414\u0436\u0438\u0431\u0443\u0442\u0438"
     ],
     "name:min_x_preferred":[
         "Djibouti"
@@ -529,7 +592,11 @@
         "\u0120ibuti"
     ],
     "name:mlt_x_variant":[
-        "D\u0121ibuwti"
+        "D\u0121ibuwti",
+        "Djibouti"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd7\uabed\uabd6\uabe4\uabd5\uabe7\uabc7\uabe4"
     ],
     "name:mon_x_preferred":[
         "\u0416\u0438\u0431\u0443\u0442\u0438"
@@ -698,6 +765,12 @@
     "name:sgs_x_preferred":[
         "D\u017e\u0117botis"
     ],
+    "name:shi_x_preferred":[
+        "Djibuti"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1075\u103b\u102e\u1087\u1015\u1030\u1038\u1010\u102e\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0da2\u0dd2\u0db6\u0dd4\u0da7\u0dd2"
     ],
@@ -713,7 +786,13 @@
     "name:sme_x_preferred":[
         "Djibouti"
     ],
+    "name:smn_x_preferred":[
+        "Djibouti"
+    ],
     "name:smo_x_preferred":[
+        "Djibouti"
+    ],
+    "name:sms_x_preferred":[
         "Djibouti"
     ],
     "name:sna_x_preferred":[
@@ -798,6 +877,9 @@
     "name:tir_x_preferred":[
         "\u1302\u1261\u1272"
     ],
+    "name:tok_x_preferred":[
+        "ma Sipusi"
+    ],
     "name:ton_x_preferred":[
         "Siputi"
     ],
@@ -806,6 +888,9 @@
     ],
     "name:tuk_x_preferred":[
         "Jibuti"
+    ],
+    "name:tum_x_preferred":[
+        "Djibouti"
     ],
     "name:tur_x_preferred":[
         "Cibuti"
@@ -837,6 +922,9 @@
     ],
     "name:vec_x_preferred":[
         "Gibuti"
+    ],
+    "name:vec_x_variant":[
+        "Zibuti"
     ],
     "name:vep_x_preferred":[
         "D\u017eibuti"
@@ -1135,7 +1223,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1617828332,
+    "wof:lastmodified":1690874638,
     "wof:name":"Djibouti",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/704/67/85670467.geojson
+++ b/data/856/704/67/85670467.geojson
@@ -45,6 +45,9 @@
     "name:ben_x_preferred":[
         "\u0986\u09b2\u09bf \u09b8\u09be\u09ac\u09bf \u0985\u099e\u09cd\u099a\u09b2"
     ],
+    "name:bos_x_preferred":[
+        "Ali Sabieh"
+    ],
     "name:bre_x_preferred":[
         "Ali Sabieh"
     ],
@@ -88,6 +91,9 @@
     "name:est_x_variant":[
         "Ali Sabiehi piirkond"
     ],
+    "name:eus_x_preferred":[
+        "Ali Sabieh eskualdea"
+    ],
     "name:fas_x_preferred":[
         "\u0639\u0644\u06cc \u0635\u0628\u06cc\u062d"
     ],
@@ -111,6 +117,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05e2\u05dc\u05d9 \u05e1\u05d1\u05d9\u05d9\u05d7"
+    ],
+    "name:heb_x_variant":[
+        "\u05e2\u05dc\u05d9 \u05e1\u05d1\u05d9\u05d7"
     ],
     "name:hin_x_preferred":[
         "\u0905\u0932\u0940 \u0938\u092c\u0940\u0939 \u092a\u094d\u0930\u0926\u0947\u0936"
@@ -149,7 +158,8 @@
         "\uc54c\ub9ac\uc0ac\ube44\uc5d0"
     ],
     "name:kor_x_variant":[
-        "\uc54c\ub9ac\uc0ac\ube44\uc5d0 \uc8fc"
+        "\uc54c\ub9ac\uc0ac\ube44\uc5d0 \uc8fc",
+        "\uc54c\ub9ac\uc0ac\ube44\uc5d0\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Al\u012b Sab\u012bhas re\u0123ions"
@@ -240,6 +250,9 @@
     ],
     "name:zho_x_variant":[
         "\u963f\u91cc\u85a9\u6bd4\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Ali Sabieh Region"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DJI",
@@ -372,7 +385,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636497598,
+    "wof:lastmodified":1690874639,
     "wof:name":"Ali Sabieh",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/73/85670473.geojson
+++ b/data/856/704/73/85670473.geojson
@@ -41,11 +41,23 @@
     "name:ara_x_variant":[
         "Djibouti"
     ],
+    "name:arg_x_preferred":[
+        "Chibuti"
+    ],
+    "name:ary_x_preferred":[
+        "\u062f\u062c\u064a\u0628\u0648\u062a\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u062c\u064a\u0628\u0648\u062a\u0649"
+    ],
     "name:ast_x_preferred":[
         "Xibuti"
     ],
     "name:aze_x_preferred":[
         "Cibuti"
+    ],
+    "name:ban_x_preferred":[
+        "Djibouti"
     ],
     "name:bcl_x_preferred":[
         "Djibouti"
@@ -103,6 +115,9 @@
     ],
     "name:deu_x_preferred":[
         "Dschibuti"
+    ],
+    "name:diq_x_preferred":[
+        "Cibuti"
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b6\u03b9\u03bc\u03c0\u03bf\u03c5\u03c4\u03af"
@@ -185,8 +200,14 @@
     "name:ido_x_preferred":[
         "Djibouti"
     ],
+    "name:ina_x_preferred":[
+        "Djibuti"
+    ],
     "name:ind_x_preferred":[
         "Djibouti"
+    ],
+    "name:ind_x_variant":[
+        "Jibouti"
     ],
     "name:isl_x_preferred":[
         "Dj\u00edb\u00fat\u00ed"
@@ -227,6 +248,9 @@
     "name:lav_x_preferred":[
         "D\u017eibuti"
     ],
+    "name:lij_x_preferred":[
+        "Gibuti"
+    ],
     "name:lit_x_preferred":[
         "D\u017eibutis"
     ],
@@ -239,6 +263,9 @@
     "name:mar_x_preferred":[
         "\u091c\u093f\u092c\u0942\u0924\u0940"
     ],
+    "name:mdf_x_preferred":[
+        "\u0414\u0436\u0438\u0431\u0443\u0442\u0438"
+    ],
     "name:mkd_x_preferred":[
         "\u040f\u0438\u0431\u0443\u0442\u0438"
     ],
@@ -250,6 +277,12 @@
     ],
     "name:msa_x_preferred":[
         "Djibouti"
+    ],
+    "name:mzn_x_preferred":[
+        "\u062c\u06cc\u0628\u0648\u062a\u06cc"
+    ],
+    "name:nah_x_preferred":[
+        "Altepetl Yibuti"
     ],
     "name:nan_x_preferred":[
         "Djibouti Chh\u012b"
@@ -269,6 +302,12 @@
     "name:oci_x_preferred":[
         "Jiboti"
     ],
+    "name:olo_x_preferred":[
+        "D\u017eibuti"
+    ],
+    "name:oss_x_preferred":[
+        "\u0414\u0436\u0438\u0431\u0443\u0442\u0438"
+    ],
     "name:pan_x_preferred":[
         "\u0a1c\u0a3f\u0a2c\u0a42\u0a24\u0a40"
     ],
@@ -283,6 +322,9 @@
     ],
     "name:por_x_preferred":[
         "Djibouti"
+    ],
+    "name:que_x_preferred":[
+        "Yiwuti"
     ],
     "name:ron_x_preferred":[
         "Djibouti"
@@ -302,6 +344,15 @@
     "name:slv_x_preferred":[
         "D\u017eibuti"
     ],
+    "name:sme_x_preferred":[
+        "Djibouti"
+    ],
+    "name:smn_x_preferred":[
+        "Djibouti"
+    ],
+    "name:sms_x_preferred":[
+        "Djibouti"
+    ],
     "name:sna_x_preferred":[
         "Djibouti"
     ],
@@ -314,6 +365,9 @@
     "name:sqi_x_preferred":[
         "Xhibuti"
     ],
+    "name:srd_x_preferred":[
+        "Gibuti"
+    ],
     "name:srp_x_preferred":[
         "\u040f\u0438\u0431\u0443\u0442\u0438"
     ],
@@ -325,6 +379,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bbf\u0baa\u0bc2\u0b9f\u0bcd\u0b9f\u0bbf"
+    ],
+    "name:tat_x_preferred":[
+        "\u0496\u0438\u0431\u0443\u0442\u0438"
     ],
     "name:tel_x_preferred":[
         "\u0c1c\u0c3f\u0c2c\u0c4b\u0c1f\u0c3f"
@@ -341,6 +398,9 @@
     "name:tuk_x_preferred":[
         "Jibuti"
     ],
+    "name:tum_x_preferred":[
+        "Djibouti"
+    ],
     "name:tur_x_preferred":[
         "Cibuti"
     ],
@@ -355,6 +415,9 @@
     ],
     "name:urd_x_preferred":[
         "\u062c\u0628\u0648\u062a\u06cc \u0639\u0644\u0627\u0642\u06c1"
+    ],
+    "name:urd_x_variant":[
+        "\u062c\u0628\u0648\u062a\u06cc"
     ],
     "name:uzb_x_preferred":[
         "Jibuti"
@@ -374,6 +437,9 @@
     "name:wol_x_preferred":[
         "Jibuti"
     ],
+    "name:wuu_x_preferred":[
+        "\u5409\u5e03\u63d0\u5e02"
+    ],
     "name:xmf_x_preferred":[
         "\u10ef\u10d8\u10d1\u10e3\u10e2\u10d8"
     ],
@@ -391,6 +457,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5409\u5e03\u5730\u5e02"
+    ],
+    "name:zul_x_preferred":[
+        "Djibouti"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DJI",
@@ -517,7 +586,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614893729,
+    "wof:lastmodified":1690874639,
     "wof:name":"Djibouti",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/77/85670477.geojson
+++ b/data/856/704/77/85670477.geojson
@@ -45,6 +45,9 @@
     "name:ben_x_preferred":[
         "\u0986\u09b0\u099f\u09be \u0985\u099e\u09cd\u099a\u09b2"
     ],
+    "name:bos_x_preferred":[
+        "Arta"
+    ],
     "name:bre_x_preferred":[
         "Arta"
     ],
@@ -77,6 +80,9 @@
     ],
     "name:est_x_preferred":[
         "Arta piirkond"
+    ],
+    "name:eus_x_preferred":[
+        "Arta eskualdea"
     ],
     "name:fas_x_preferred":[
         "\u0622\u0631\u062a\u0627"
@@ -142,7 +148,8 @@
         "\uc544\ub974\ud0c0"
     ],
     "name:kor_x_variant":[
-        "\uc544\ub974\ud0c0 \uc8fc"
+        "\uc544\ub974\ud0c0 \uc8fc",
+        "\uc544\ub974\ud0c0\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Artas re\u0123ions"
@@ -186,6 +193,9 @@
     "name:sin_x_preferred":[
         "\u0d85\u0dbb\u0dca\u0da7\u0dcf \u0d9a\u0dbd\u0dcf\u0db4\u0dba"
     ],
+    "name:som_x_preferred":[
+        "Gobolka Carta"
+    ],
     "name:spa_x_preferred":[
         "Arta"
     ],
@@ -218,6 +228,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u723e\u5854\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Arta Region"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DJI",
@@ -343,7 +356,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614893729,
+    "wof:lastmodified":1690874640,
     "wof:name":"Arta",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/83/85670483.geojson
+++ b/data/856/704/83/85670483.geojson
@@ -42,6 +42,9 @@
     "name:ben_x_preferred":[
         "\u09a1\u09bf\u0995\u09bf \u0985\u099e\u09cd\u099a\u09b2"
     ],
+    "name:bos_x_preferred":[
+        "Dikhil"
+    ],
     "name:bre_x_preferred":[
         "Dikhil"
     ],
@@ -71,6 +74,9 @@
     ],
     "name:est_x_preferred":[
         "Dikhili piirkond"
+    ],
+    "name:eus_x_preferred":[
+        "Dikhil eskualdea"
     ],
     "name:fas_x_preferred":[
         "\u0645\u0646\u0637\u0642\u0647 \u062f\u062e\u06cc\u0644"
@@ -115,7 +121,8 @@
         "\ub514\ud06c\ud790 \uc8fc"
     ],
     "name:kor_x_variant":[
-        "\ub514\ud0ac \uc8fc"
+        "\ub514\ud0ac \uc8fc",
+        "\ub514\ud0ac\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Dihilas re\u0123ions"
@@ -188,6 +195,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8fea\u57fa\u723e\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Dikhil Region"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DJI",
@@ -314,7 +324,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636497599,
+    "wof:lastmodified":1690874640,
     "wof:name":"Dikhil",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/85/85670485.geojson
+++ b/data/856/704/85/85670485.geojson
@@ -36,11 +36,17 @@
         "\u0625\u0642\u0644\u064a\u0645 \u0623\u0648\u0628\u0648\u0643",
         "Obock"
     ],
+    "name:aze_x_preferred":[
+        "Obok regionu"
+    ],
     "name:bel_x_preferred":[
         "\u0420\u044d\u0433\u0456\u0451\u043d \u0410\u0431\u043e\u043a"
     ],
     "name:ben_x_preferred":[
         "\u0993\u09ac\u09be\u0995 \u0985\u099e\u09cd\u099a\u09b2"
+    ],
+    "name:bos_x_preferred":[
+        "Obock"
     ],
     "name:bre_x_preferred":[
         "Obock"
@@ -72,6 +78,9 @@
     "name:est_x_preferred":[
         "Obocki piirkond"
     ],
+    "name:eus_x_preferred":[
+        "Obock eskualdea"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0646\u0637\u0642\u0647 \u0627\u0648\u0628\u0648\u06a9"
     ],
@@ -92,6 +101,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0a93\u0aac\u0acb\u0a95 \u0aaa\u0acd\u0ab0\u0aa6\u0ac7\u0ab6"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d0\u05d5\u05d1\u05d5\u05e7"
     ],
     "name:hin_x_preferred":[
         "\u0913\u092c\u0949\u0915 \u0915\u094d\u0937\u0947\u0924\u094d\u0930"
@@ -116,6 +128,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc624\ubcf4\ud06c \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc624\ubcf4\ud06c\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Ubukas re\u0123ions"
@@ -182,6 +197,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5967\u535a\u514b\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Obock Region"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DJI",
@@ -308,7 +326,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636497599,
+    "wof:lastmodified":1690874640,
     "wof:name":"Obock",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/91/85670491.geojson
+++ b/data/856/704/91/85670491.geojson
@@ -42,6 +42,9 @@
     "name:ben_x_preferred":[
         "\u09a4\u09be\u099c\u09c1\u09b0\u09be\u09b9 \u0985\u099e\u09cd\u099a\u09b2"
     ],
+    "name:bos_x_preferred":[
+        "Tadjourah"
+    ],
     "name:bre_x_preferred":[
         "Tadjourah"
     ],
@@ -72,6 +75,9 @@
     "name:est_x_preferred":[
         "Tadjoura piirkond"
     ],
+    "name:eus_x_preferred":[
+        "Tadjourah eskualdea"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0646\u0637\u0642\u0647 \u062a\u0627\u062c\u0648\u0631\u0647"
     ],
@@ -89,6 +95,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0aa4\u0a9c\u0acc\u0ab0\u0ab9 \u0aaa\u0acd\u0ab0\u0aa6\u0ac7\u0ab6"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d8\u05d0\u05d2'\u05d5\u05e8\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u0924\u0926\u091c\u094c\u0930\u093e \u0915\u094d\u0937\u0947\u0924\u094d\u0930"
@@ -118,7 +127,8 @@
         "\ud0c0\uc8fc\ub77c\ud750 \uc8fc"
     ],
     "name:kor_x_variant":[
-        "\ud0c0\uc8fc\ub77c \uc8fc"
+        "\ud0c0\uc8fc\ub77c \uc8fc",
+        "\ud0c0\uc8fc\ub77c\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Ted\u017e\u016bras re\u0123ions"
@@ -188,6 +198,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5854\u6731\u62c9\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Tadjourah Region"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DJI",
@@ -313,7 +326,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636497598,
+    "wof:lastmodified":1690874639,
     "wof:name":"Tadjourah",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/890/435/321/890435321.geojson
+++ b/data/890/435/321/890435321.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0639\u0644\u064a \u0635\u0628\u064a\u062d"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u0644\u0649 \u0635\u0628\u064a\u062d"
+    ],
+    "name:ast_x_preferred":[
+        "Ali Sabieh"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0644\u06cc \u0635\u0628\u06cc\u062d"
     ],
@@ -52,6 +58,9 @@
     "name:est_x_preferred":[
         "Ali Sabieh"
     ],
+    "name:eus_x_preferred":[
+        "Ali Sabieh"
+    ],
     "name:fas_x_preferred":[
         "\u0639\u0644\u06cc \u0635\u0628\u06cc\u062d"
     ],
@@ -63,6 +72,9 @@
     ],
     "name:frr_x_preferred":[
         "Ali Sabieh"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e2\u05dc\u05d9 \u05e1\u05d1\u05d9\u05d7"
     ],
     "name:hun_x_preferred":[
         "Ali Szabieh"
@@ -110,7 +122,11 @@
         "\u0410\u043b\u0438-\u0421\u0430\u0431\u0438\u0435"
     ],
     "name:rus_x_variant":[
-        "\u0410\u043b\u0438-\u0421\u0430\u0431\u044c\u0435"
+        "\u0410\u043b\u0438-\u0421\u0430\u0431\u044c\u0435",
+        "\u0410\u043b\u0438-\u0421\u0430\u0431\u0438\u0445"
+    ],
+    "name:som_x_preferred":[
+        "Cali Sabiix"
     ],
     "name:spa_x_preferred":[
         "Ali Sabieh"
@@ -121,14 +137,23 @@
     "name:tur_x_preferred":[
         "Ali Sabieh"
     ],
+    "name:ukr_x_preferred":[
+        "\u0410\u043b\u0456-\u0421\u0430\u0431\u0456\u0445"
+    ],
     "name:und_x_variant":[
         "Ali Sabiet"
     ],
     "name:urd_x_preferred":[
         "\u0639\u0644\u06cc \u0635\u0628\u06cc\u062d"
     ],
+    "name:vie_x_preferred":[
+        "Ali Sabieh"
+    ],
     "name:zho_x_preferred":[
         "\u963f\u91cc\u8428\u6bd4\u8036"
+    ],
+    "name:zul_x_preferred":[
+        "Ali Sabieh"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Djibouti",
@@ -253,7 +278,7 @@
         }
     ],
     "wof:id":890435321,
-    "wof:lastmodified":1566721457,
+    "wof:lastmodified":1690874643,
     "wof:name":"'Ali Sabieh",
     "wof:parent_id":1108759739,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.