### PR TITLE
dj concordances, placetype local, and more

### DIFF
--- a/data/110/875/973/9/1108759739.geojson
+++ b/data/110/875/973/9/1108759739.geojson
@@ -153,7 +153,7 @@
         }
     ],
     "wof:id":1108759739,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886739,
     "wof:name":"Ali Sabieh",
     "wof:parent_id":85670467,
     "wof:placetype":"county",

--- a/data/110/875/974/1/1108759741.geojson
+++ b/data/110/875/974/1/1108759741.geojson
@@ -150,7 +150,7 @@
         }
     ],
     "wof:id":1108759741,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886739,
     "wof:name":"Dikhil",
     "wof:parent_id":85670477,
     "wof:placetype":"county",

--- a/data/110/875/974/5/1108759745.geojson
+++ b/data/110/875/974/5/1108759745.geojson
@@ -657,7 +657,7 @@
         }
     ],
     "wof:id":1108759745,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886137,
     "wof:name":"Djibouti",
     "wof:parent_id":85670477,
     "wof:placetype":"county",

--- a/data/110/875/974/7/1108759747.geojson
+++ b/data/110/875/974/7/1108759747.geojson
@@ -99,7 +99,7 @@
         }
     ],
     "wof:id":1108759747,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886137,
     "wof:name":"Yoboki",
     "wof:parent_id":85670477,
     "wof:placetype":"county",

--- a/data/110/875/974/9/1108759749.geojson
+++ b/data/110/875/974/9/1108759749.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":1108759749,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886251,
     "wof:name":"As Eyla",
     "wof:parent_id":85670483,
     "wof:placetype":"county",

--- a/data/110/875/975/1/1108759751.geojson
+++ b/data/110/875/975/1/1108759751.geojson
@@ -150,7 +150,7 @@
         }
     ],
     "wof:id":1108759751,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886739,
     "wof:name":"Dikhil",
     "wof:parent_id":85670483,
     "wof:placetype":"county",

--- a/data/110/875/975/3/1108759753.geojson
+++ b/data/110/875/975/3/1108759753.geojson
@@ -99,7 +99,7 @@
         }
     ],
     "wof:id":1108759753,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886138,
     "wof:name":"Yoboki",
     "wof:parent_id":85670483,
     "wof:placetype":"county",

--- a/data/110/875/975/5/1108759755.geojson
+++ b/data/110/875/975/5/1108759755.geojson
@@ -660,7 +660,7 @@
         }
     ],
     "wof:id":1108759755,
-    "wof:lastmodified":1694497946,
+    "wof:lastmodified":1695886457,
     "wof:name":"Djibouti",
     "wof:parent_id":85670473,
     "wof:placetype":"county",

--- a/data/110/875/975/7/1108759757.geojson
+++ b/data/110/875/975/7/1108759757.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":1108759757,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886249,
     "wof:name":"Alaili Dadda",
     "wof:parent_id":85670485,
     "wof:placetype":"county",

--- a/data/110/875/975/9/1108759759.geojson
+++ b/data/110/875/975/9/1108759759.geojson
@@ -162,7 +162,7 @@
         }
     ],
     "wof:id":1108759759,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886739,
     "wof:name":"Obock",
     "wof:parent_id":85670485,
     "wof:placetype":"county",

--- a/data/110/875/976/3/1108759763.geojson
+++ b/data/110/875/976/3/1108759763.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":1108759763,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886253,
     "wof:name":"Balha",
     "wof:parent_id":85670491,
     "wof:placetype":"county",

--- a/data/110/875/976/5/1108759765.geojson
+++ b/data/110/875/976/5/1108759765.geojson
@@ -96,7 +96,7 @@
         }
     ],
     "wof:id":1108759765,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886138,
     "wof:name":"Dorra",
     "wof:parent_id":85670491,
     "wof:placetype":"county",

--- a/data/110/875/976/7/1108759767.geojson
+++ b/data/110/875/976/7/1108759767.geojson
@@ -87,7 +87,7 @@
         }
     ],
     "wof:id":1108759767,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886137,
     "wof:name":"Randa",
     "wof:parent_id":85670491,
     "wof:placetype":"county",

--- a/data/110/875/976/9/1108759769.geojson
+++ b/data/110/875/976/9/1108759769.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1108759769,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886739,
     "wof:name":"Tadjourah",
     "wof:parent_id":85670491,
     "wof:placetype":"county",

--- a/data/856/323/19/85632319.geojson
+++ b/data/856/323/19/85632319.geojson
@@ -1191,6 +1191,7 @@
         "hasc:id":"DJ",
         "icao:code":"J2",
         "ioc:id":"DJI",
+        "iso:code":"DJ",
         "itu:id":"DJI",
         "m49:code":"262",
         "marc:id":"ft",
@@ -1204,6 +1205,7 @@
         "wk:page":"Djibouti",
         "wmo:id":"DJ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DJ",
     "wof:country_alpha3":"DJI",
     "wof:geom_alt":[
@@ -1227,7 +1229,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1694639578,
+    "wof:lastmodified":1695881238,
     "wof:name":"Djibouti",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/704/67/85670467.geojson
+++ b/data/856/704/67/85670467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175796,
-    "geom:area_square_m":2132048897.984635,
+    "geom:area_square_m":2132048897.984759,
     "geom:bbox":"42.659534,10.981667,43.200116,11.492556",
     "geom:latitude":11.241005,
     "geom:longitude":42.907204,
@@ -356,11 +356,13 @@
         "gn:id":225282,
         "gp:id":2345156,
         "hasc:id":"DJ.AS",
+        "iso:code":"DJ-AS",
         "iso:id":"DJ-AS",
         "qs_pg:id":922446,
         "unlc:id":"DJ-AS",
         "wd:id":"Q821008"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1108759739
     ],
@@ -368,7 +370,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1610a86dec725f02ecf02286b2d55ac5",
+    "wof:geomhash":"43a224c09c2c0efe40164fab0778e4fe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -385,7 +387,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874639,
+    "wof:lastmodified":1695884856,
     "wof:name":"Ali Sabieh",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/73/85670473.geojson
+++ b/data/856/704/73/85670473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017227,
-    "geom:area_square_m":208697056.530409,
+    "geom:area_square_m":208697056.530444,
     "geom:bbox":"42.891224,11.51878,43.216194,11.733778",
     "geom:latitude":11.565241,
     "geom:longitude":43.045724,
@@ -558,10 +558,12 @@
         "gn:id":223818,
         "gp:id":2345158,
         "hasc:id":"DJ.DB",
+        "iso:code":"DJ-DJ",
         "iso:id":"DJ-DJ",
         "qs_pg:id":453291,
         "wd:id":"Q3604"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1108759755
     ],
@@ -569,7 +571,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b2575e4610d1010cf44e675c80ec6019",
+    "wof:geomhash":"62d41c7840ee6a9cde268f846e11a338",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -586,7 +588,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874639,
+    "wof:lastmodified":1695884504,
     "wof:name":"Djibouti",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/77/85670477.geojson
+++ b/data/856/704/77/85670477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133594,
-    "geom:area_square_m":1618983483.509211,
+    "geom:area_square_m":1618984451.317969,
     "geom:bbox":"42.368204,11.273965,43.259083,11.648105",
     "geom:latitude":11.459694,
     "geom:longitude":42.732838,
@@ -331,15 +331,17 @@
         "gn:id":449265,
         "gp:id":1310928,
         "hasc:id":"DJ.AR",
+        "iso:code":"DJ-AR",
         "iso:id":"DJ-AR",
         "unlc:id":"DJ-AR",
         "wd:id":"Q705941"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DJ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe32ee55f43cd4bd5bbd288b2a93bf51",
+    "wof:geomhash":"e4744c31e031ebe014aa04dac784df0c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -356,7 +358,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874640,
+    "wof:lastmodified":1695884504,
     "wof:name":"Arta",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/83/85670483.geojson
+++ b/data/856/704/83/85670483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.555861,
-    "geom:area_square_m":6738489670.951048,
+    "geom:area_square_m":6738489368.915375,
     "geom:bbox":"41.759722,10.931944,42.668394,11.935271",
     "geom:latitude":11.365103,
     "geom:longitude":42.136536,
@@ -297,17 +297,19 @@
         "gn:id":223889,
         "gp:id":2345157,
         "hasc:id":"DJ.DK",
+        "iso:code":"DJ-DI",
         "iso:id":"DJ-DI",
         "qs_pg:id":219539,
         "unlc:id":"DJ-DI",
         "wd:id":"Q283979",
         "wk:page":"Dikhil Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DJ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cff49b0b9045e0957aacbf22e5cb5e8c",
+    "wof:geomhash":"51186ba1ab67eed673985058df159dac",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -324,7 +326,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874640,
+    "wof:lastmodified":1695884856,
     "wof:name":"Dikhil",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/85/85670485.geojson
+++ b/data/856/704/85/85670485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.368915,
-    "geom:area_square_m":4457333972.83127,
+    "geom:area_square_m":4457334279.951851,
     "geom:bbox":"42.709403,11.82943,43.444527,12.713697",
     "geom:latitude":12.278776,
     "geom:longitude":43.0875,
@@ -299,17 +299,19 @@
         "gn:id":221525,
         "gp:id":2345159,
         "hasc:id":"DJ.OB",
+        "iso:code":"DJ-OB",
         "iso:id":"DJ-OB",
         "qs_pg:id":984077,
         "unlc:id":"DJ-OB",
         "wd:id":"Q844929",
         "wk:page":"Obock Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DJ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"178f7e13e70eac6d672e3bfbe88ab675",
+    "wof:geomhash":"6ad77db54ac8384ddd03c66832fd39c5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874640,
+    "wof:lastmodified":1695884856,
     "wof:name":"Obock",
     "wof:parent_id":85632319,
     "wof:placetype":"region",

--- a/data/856/704/91/85670491.geojson
+++ b/data/856/704/91/85670491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.541841,
-    "geom:area_square_m":6553387065.359782,
+    "geom:area_square_m":6553386536.494567,
     "geom:bbox":"42.031125,11.551278,43.071538,12.526912",
     "geom:latitude":12.005143,
     "geom:longitude":42.531936,
@@ -300,16 +300,18 @@
         "gn:id":220781,
         "gp:id":2345160,
         "hasc:id":"DJ.TA",
+        "iso:code":"DJ-TA",
         "iso:id":"DJ-TA",
         "qs_pg:id":900665,
         "unlc:id":"DJ-TA",
         "wd:id":"Q645896"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DJ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6deb841c139a7acf96b840f496140c1d",
+    "wof:geomhash":"40127deba1a0447e66d208f9da6953e6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690874639,
+    "wof:lastmodified":1695884856,
     "wof:name":"Tadjourah",
     "wof:parent_id":85632319,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.